### PR TITLE
Add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,29 @@
+# Security Policy
+
+## Supported versions
+
+The following table describes the versions of this project that are currently supported with security updates:
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 0.x     | :white_check_mark: |
+
+## Responsible Disclosure Security Policy
+
+A responsible disclosure policy helps protect users of the project from publicly disclosed security vulnerabilities without a fix by employing a process where vulnerabilities are first triaged in a private manner, and only publicly disclosed after a reasonable time period that allows patching the vulnerability and provides an upgrade path for users.
+
+When contacting us directly via email, we will do our best efforts to respond in a reasonable time to resolve the issue. When contacting a security program their disclosure policy will provide details on time-frame, processes and paid bounties.
+
+We kindly ask you to refrain from malicious acts that put our users, the project, or any of the project's team members at risk.
+
+## Reporting a Security Issue
+
+We consider the security of our systems a top priority. But no matter how much effort we put into system security, there can still be vulnerabilities present.
+
+If you discover a security vulnerability, please use one of the following means of communications to report it to us:
+
+- Report the security issue to the Node.js Security Working Group through the [HackerOne program](https://hackerone.com/nodejs-ecosystem) for ecosystem modules on npm, or to [Snyk Security Team](https://snyk.io/vulnerability-disclosure). They will help triage the security issue and work with all involved parties to remediate and release a fix.
+
+- Report the security issue to the MetaMask team directly at [metamask.security@consensys.net](mailto:metamask.security@consensys.net).
+
+Your efforts to responsibly disclose your findings are sincerely appreciated and will be taken into account to acknowledge your contributions.


### PR DESCRIPTION
See [_Creating a default community health file - GitHub Help_](https://help.github.com/en/github/building-a-strong-community/creating-a-default-community-health-file)

This PR adds an **organization-wide** default `SECURITY.md` file. This file offers instructions for reporting security vulnerabilities in our projects.

This `SECURITY.md` file is loosely based on:

- [lodash's `SECURITY.md` file](https://github.com/lodash/lodash/blob/master/SECURITY.md)
- [Agoric's `SECURITY.md` file for SES-shim](https://github.com/Agoric/SES-shim/blob/master/SECURITY.md)

---

Closes https://github.com/MetaMask/eth-trezor-keyring/issues/32
Closes https://github.com/MetaMask/eth-ledger-bridge-keyring/issues/35
Closes https://github.com/MetaMask/controllers/issues/218
Closes https://github.com/MetaMask/eth-sig-util/issues/86
Closes https://github.com/MetaMask/KeyringController/pull/52