### PR TITLE
Remove "Supported versions" section

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,13 +1,5 @@
 # Security Policy
 
-## Supported versions
-
-The following table describes the versions of this project that are currently supported with security updates:
-
-| Version | Supported          |
-| ------- | ------------------ |
-| 0.x     | :white_check_mark: |
-
 ## Responsible Disclosure Security Policy
 
 A responsible disclosure policy helps protect users of the project from publicly disclosed security vulnerabilities without a fix by employing a process where vulnerabilities are first triaged in a private manner, and only publicly disclosed after a reasonable time period that allows patching the vulnerability and provides an upgrade path for users.


### PR DESCRIPTION
This PR removes the _Supported versions_ section from `SECURITY.md` as it doesn't make sense for a default across repos which may have different versions.