### PR TITLE
fix: gate release branch PRs with team review, scope fallback to non-release

### DIFF
--- a/policy.yml
+++ b/policy.yml
@@ -8,7 +8,8 @@ policy:
   approval:
     - or:
         - "cherry-pick auto-approval"
-        - "no approval necessary"
+        - "release branch review"
+        - "non-release fallback"
 
 approval_rules:
   - name: "cherry-pick auto-approval"
@@ -24,7 +25,22 @@ approval_rules:
     requires:
       count: 0
 
-  - name: "no approval necessary"
-    description: "Fallback rule — matches all PRs so policy-bot reports a clean status instead of an error"
+  - name: "release branch review"
+    description: "Require release-team review for all PRs targeting release branches"
+    if:
+      targets_branch:
+        pattern: "^release/.*$"
+    requires:
+      count: 1
+      teams:
+        - "MetaMask/release-team"
+
+  # RE2-compatible negation of "^release/.*$" (Go regexp does not support lookaheads).
+  # Matches any branch name that does NOT start with "release/".
+  - name: "non-release fallback"
+    description: "Auto-approve PRs targeting non-release branches so policy-bot posts a clean status"
+    if:
+      targets_branch:
+        pattern: "^([^r]|r[^e]|re[^l]|rel[^e]|rele[^a]|relea[^s]|releas[^e]|release[^/]).*$|^.{0,7}$"
     requires:
       count: 0


### PR DESCRIPTION
## Summary

Replaces the blanket `"no approval necessary"` fallback (from PR #83) with two scoped rules so that PRs targeting `release/*` branches are properly gated.

### Rules

| Rule | Scope | Requires | Purpose |
|------|-------|----------|---------|
| `cherry-pick auto-approval` | `release/*` + cherry-pick title + < 200 LOC | count: 0 | Auto-approve qualifying cherry-picks |
| `release branch review` | `release/*` (any PR) | 1 approval from `MetaMask/release-team` | Gate all other release PRs |
| `non-release fallback` | Everything **except** `release/*` | count: 0 | Clean approved status for non-release PRs |

The fallback uses a RE2-compatible negation regex since Go's regexp engine does not support lookaheads:
```
^([^r]|r[^e]|re[^l]|rel[^e]|rele[^a]|relea[^s]|releas[^e]|release[^/]).*$|^.{0,7}$
```

### Evaluation scenarios

| # | Scenario | Rule 1 | Rule 2 | Rule 3 | `or` result |
|---|----------|--------|--------|--------|-------------|
| 1 | Cherry-pick PR → `release/*` (< 200 LOC) | ✅ approved | ⏳ pending | skipped | **SUCCESS** |
| 2 | Regular PR → `main` | skipped | skipped | ✅ approved | **SUCCESS** |
| 3 | Wrong title (no cherry-pick) → `release/*` | skipped | ⏳ pending | skipped | **PENDING** |
| 4 | Large PR (> 200 LOC) → `release/*` | skipped | ⏳ pending | skipped | **PENDING** |

## Test plan

- [ ] **Scenario 1**: Cherry-pick PR targeting `release/*` with correct title and < 200 LOC → `success`
- [ ] **Scenario 2**: Regular PR targeting `main` → `success` (fallback rule)
- [ ] **Scenario 3**: PR targeting `release/*` without "cherry-pick" in title → `pending`
- [ ] **Scenario 4**: Large cherry-pick PR (> 200 LOC) targeting `release/*` → `pending`

🤖 Generated with [Claude Code](https://claude.com/claude-code)