### PR TITLE
fix(INFRA-3359): restrict cherry-pick auto-approval to MetaMask org members

### DIFF
--- a/policy.yml
+++ b/policy.yml
@@ -15,6 +15,9 @@ approval_rules:
   - name: "cherry-pick auto-approval"
     description: "Auto-approve cherry-pick PRs to release branches that meet all criteria"
     if:
+      has_author_in:
+        organizations:
+          - "MetaMask"
       title:
         matches:
           - "(?i)cherry.?pick"


### PR DESCRIPTION
## Problem

`cherry-pick auto-approval` had no author check. On public repos, an external user could open a fork PR matching the title/branch/LOC criteria and get a `success` status from policy-bot (status spoofing).

## Fix

Add `has_author_in: organizations: ["MetaMask"]` to the rule's `if` block. Fork PRs from non-members now fall through to `release branch review`, which requires `MetaMask/release-team` approval.

## Evaluation logic (unchanged for org members)

| Scenario | Result |
|---|---|
| Org member cherry-pick → `release/*` (<200 LOC) | **success** |
| Non-member PR → `release/*` | **pending** (team review required) |
| Any PR → `main` | **success** |

Jira: INFRA-3359