### PR TITLE
metamask

### DIFF
--- a/workflow-templates/publish-release.yml
+++ b/workflow-templates/publish-release.yml
@@ -18,6 +18,6 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: ${{ steps.nvm.outputs.NODE_VERSION }}
-      - uses: MetaMask/action-publish-release@0.0.2
+      - uses: MetaMask/action-publish-release@v0.0.3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk CI-only change that updates a GitHub Action version in the release workflow. Potential impact is limited to the release automation behavior when the workflow runs.
> 
> **Overview**
> Updates the `Publish Release` GitHub Actions workflow to use `MetaMask/action-publish-release@v0.0.3` (from `0.0.2`) when publishing releases after merge.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e68ba1a02f75c6ce9c9516b468c352776a31aac9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->